### PR TITLE
Fixed label issues: new scheme

### DIFF
--- a/Notebooks/zoobot_testing.ipynb
+++ b/Notebooks/zoobot_testing.ipynb
@@ -247,7 +247,7 @@
     "\n",
     "from auxiliary_functions import (aggressive_arcsinh_scaling, ClassificationDataset_values, \n",
     "                        train_epoch, evaluate, compute_metrics, evaluate_with_probabilities, plot_confusion_matrix)\n",
-    "from DataCore import ClassificationDataset_labels\n"
+    "from DataCore import ClassificationDataset_labels,ClassificationArrayDataset\n"
    ]
   },
   {
@@ -264,6 +264,8 @@
     }
    ],
    "source": [
+    "unityTransform = lambda x: x\n",
+    "\n",
     "# Load labels and data\n",
     "label_file = \"/net/virgo01/data/users/spirov/Deep/catalog_tng100_jwst_all_50sns.fits\"\n",
     "labels = fits.open(label_file)[1]  # second HDU\n",
@@ -271,7 +273,7 @@
     "datadir = \"/net/virgo01/data/users/mahesh/DeepLearning/data/\"\n",
     "\n",
     "# Create the dataset using the scaling\n",
-    "dataset = ClassificationDataset_labels(datadir, labels, aggressive_arcsinh_scaling)\n",
+    "dataset = ClassificationArrayDataset(datadir, labels, unityTransform)\n",
     "\n",
     "# # dataset splits\n",
     "# total_samples = len(dataset)\n",
@@ -700,7 +702,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/Scripts/DataCore.py
+++ b/Scripts/DataCore.py
@@ -89,3 +89,66 @@ class ClassificationDataset_labels(Dataset):
         
         label_tensor = torch.tensor(class_label, dtype=torch.long)
         return img_tensor, label_tensor
+    
+    
+class ClassificationArrayDataset(Dataset):
+    def __init__(self, datadir, labels, transform):
+        """
+        Args:
+          datadir (str): Base directory containing the FITS images.
+          labels: FITS HDU (labels.data) with columns 'is_pre_merger', 'is_ongoing_merger', 'is_post_merger'.
+          transform (callable): Function to apply to the raw image.
+        """
+        self.datadir = datadir
+        self.labels = labels
+        self.transform = transform
+        self.length = len(self.labels.data)
+    
+    def __len__(self):
+        return self.length
+    
+    def __getitem__(self, idx):
+        row = self.labels.data[idx]
+        ID = row["ID"]
+        snap = row["snapnum"]
+        
+        # Build file path for your FITS image
+        file_path = os.path.join(
+            self.datadir,
+            f"mock_v4/F150W/L75n1820TNG/snapnum_0{snap}/xy/"
+            f"JWST_50kpc_F150W_TNG100_sn0{snap}_xy_broadband_{ID}.fits"
+        )
+        
+        # Load FITS image
+        with fits.open(file_path) as hdul:
+            img_data = hdul[0].data.astype(np.float32).newbyteorder("=")
+        
+        # Apply the transformation
+        img_transformed = self.transform(img_data)
+        
+        # Convert to tensor and replicate channel to get shape [3, H, W]
+        img_tensor = torch.tensor(img_transformed).unsqueeze(0).repeat(3, 1, 1)
+        
+        # Read flags
+        is_pre = (row['is_pre_merger'] == 1)
+        is_ongoing = (row['is_ongoing_merger'] == 1)
+        is_post = (row['is_post_merger'] == 1)
+        
+        # 3-class labeling logic, multiple things can be true:
+        # 00 -> non merger
+        # 10 -> pre merger
+        # 01 -> post merger
+        # 11 -> post merger, will merge again
+        
+        
+        labelList = [0,0]
+        
+        
+        if is_pre:
+            labelList[0] = 1
+        if is_ongoing or is_post:
+            labelList[1] = 1
+        
+        
+        label_tensor = torch.tensor(labelList, dtype=torch.int) #if there's a dtype error, change this to long
+        return img_tensor, label_tensor

--- a/Scripts/auxiliary_functions.py
+++ b/Scripts/auxiliary_functions.py
@@ -42,6 +42,35 @@ def aggressive_arcsinh_scaling(image):
     image_norm = (image_scaled - np.min(image_scaled)) / (np.max(image_scaled) - np.min(image_scaled) + 1e-8)
     return image_norm
 
+
+#TODO:
+#Test binning effects on learning
+
+def binningTransform(image: torch.Tensor, sizeBin: int = 1) -> torch.Tensor:  
+    """
+    Apply binning (averaging) to an image tensor.
+    
+    Args:
+        image (torch.Tensor): Input image tensor of shape (C, H, W).
+        sizeBin (int, optional): Binning factor. Default is 1 (no binning).
+    
+    Returns:
+        torch.Tensor: Binned image tensor of shape (C, H//sizeBin, W//sizeBin).
+    """
+    if sizeBin <= 1:
+        return image  # No binning needed
+    
+    C, H, W = image.shape
+    if H % sizeBin != 0 or W % sizeBin != 0:
+        raise ValueError("Image dimensions must be divisible by binning factor.")
+    
+    # Reshape and average over binning regions
+    image = image.view(C, H // sizeBin, sizeBin, W // sizeBin, sizeBin)
+    binnedImage = image.mean(dim=(2, 4))
+    
+    return binnedImage
+
+
 # Dataset for Classification
 class ClassificationDataset_values(Dataset):
     def __init__(self, datadir, labels, transform):


### PR DESCRIPTION
The datasets now use an array as a label. index 0 and 1 independently set if there is a merger in the past or future. Both or neither can be true.

I added a binning function for later tests on learning rate (would be cool to check). Also made some small changes to zoobot, but didn't finish changing.

TODO: (Andrea)
please adjust our zoobot's final layer to have 2 neurons, instead of 1 (like we did for transfer learning). You can literally say model.classifier[indx] = linear for example. For loss use BCEWithLogitsLoss.